### PR TITLE
fix: correct broken markdown formatting in beehiiv DNS guide

### DIFF
--- a/website/changelog/2026/april.md
+++ b/website/changelog/2026/april.md
@@ -8,6 +8,10 @@ description: Changes and additions for April 2026
 
 ## 📅 2026-04-24
 
+### 🔧 Bug Fixes
+- **Beehiiv DNS Guide Formatting Fix**: Fixed broken markdown formatting in the Beehiiv DNS configuration guide — an unclosed code fence caused most of the page to render as one giant code block
+  - **Link**: [Beehiiv Custom Domain Setup](/docs/engineer/Misc/beehiiv-dns)
+
 ### 📚 Documentation Updates
 - **KLV Investigation Post-Mortem**: Added post-mortem documentation for debugging a one-byte PES header bug in a drone surveillance MPEG-TS pipeline — renamed and reformatted to match site conventions
   - **Link**: [KLV Metadata Investigation](/docs/engineer/Misc/klv-investigation-postmortem)

--- a/website/docs/engineer/Misc/beehiiv-dns.md
+++ b/website/docs/engineer/Misc/beehiiv-dns.md
@@ -7,18 +7,18 @@ sidebar_position: 6
 ---
 
 
-I recently moved my newsletter from Substack, to Beehiiv which meant moving my custom domain over as well, but Cloudflare’s defaults (especially proxying and CAA UI quirks) can block verification. This is a precise, Cloudflare-first setup that worked for `www.uncommonengineer.com`, including the exact records, proxy states, and validation commands.
+I recently moved my newsletter from Substack, to Beehiiv which meant moving my custom domain over as well, but Cloudflare's defaults (especially proxying and CAA UI quirks) can block verification. This is a precise, Cloudflare-first setup that worked for `www.uncommonengineer.com`, including the exact records, proxy states, and validation commands.
 
 ---
 
 ## 1) Why Cloudflare needs special care
 
-Cloudflare tends to “help” by proxying CNAMEs (orange cloud) and its CAA UI can be unintuitive.
+Cloudflare tends to "help" by proxying CNAMEs (orange cloud) and its CAA UI can be unintuitive.
 
 Beehiiv requires:
 
 - Direct, unproxied DNS resolution for its verification CNAMEs (so Beehiiv/SendGrid can see `sendgrid.net`).
-- Correct CAA authorizations so a CA (Let’s Encrypt / Google PKI) may issue certificates for your host.
+- Correct CAA authorizations so a CA (Let's Encrypt / Google PKI) may issue certificates for your host.
 
 :::caution
 
@@ -34,8 +34,7 @@ If you proxy or mis-enter CAA records, Beehiiv will fail verification with error
 
 Beehiiv provided the following for `www.uncommonengineer.com`. Your IDs may differ; copy the *form*, not the literal IDs.
 
-
-```
+```text
 CNAMEs (SendGrid — must be unproxied, DNS-only):
     Type:   CNAME
     Name:   elinkb04.www
@@ -47,7 +46,7 @@ CNAMEs (SendGrid — must be unproxied, DNS-only):
     Value:  sendgrid.net
     Proxy:  DNS Only (grey cloud)
 
-CAA (allow certificate issuance for www via Let’s Encrypt and Google PKI):
+CAA (allow certificate issuance for www via Let's Encrypt and Google PKI):
     Type:   CAA
     Name:   www
     Flags:  0
@@ -59,20 +58,21 @@ CAA (allow certificate issuance for www via Let’s Encrypt and Google PKI):
     Flags:  0
     Tag:    issuewild
     Value:  pki.goog
+```
 
-Notes:
+**Notes:**
 
-- Cloudflare’s CAA “Tag” choices map as follows:
-  - “Only allow specific hostnames” → creates `issue`
-  - “Only allow wildcards” → creates `issuewild`
-- Beehiiv asked for `issuewild`. In Cloudflare, choose “Only allow wildcards” and set the CA domain to `letsencrypt.org` and `pki.goog`.
-- Do not paste the string “0 issuewild letsencrypt.org” into the CA field. Cloudflare builds the wire format from your Flag/Tag/Value selections.
+- Cloudflare's CAA "Tag" choices map as follows:
+  - "Only allow specific hostnames" → creates `issue`
+  - "Only allow wildcards" → creates `issuewild`
+- Beehiiv asked for `issuewild`. In Cloudflare, choose "Only allow wildcards" and set the CA domain to `letsencrypt.org` and `pki.goog`.
+- Do not paste the string "0 issuewild letsencrypt.org" into the CA field. Cloudflare builds the wire format from your Flag/Tag/Value selections.
 
 ---
 
 ## 3) Add the CAA records in Cloudflare (exact UI steps)
 
-For Let’s Encrypt:
+For Let's Encrypt:
 
 - Type: CAA
 - Name: www
@@ -98,34 +98,52 @@ Optional (harmless and sometimes helpful): also add non-wildcard `issue` entries
 ## 4) Proxy settings (critical)
 
 - The SendGrid verification CNAMEs **must be DNS-only** (grey cloud). If proxied (orange), Beehiiv/SendGrid will not see `sendgrid.net` and verification fails.
-- CAA records have no proxy toggle (they’re pure DNS).
+- CAA records have no proxy toggle (they're pure DNS).
 - You may continue to proxy unrelated hosts (e.g., your apex or other subdomains). Just keep Beehiiv-supplied CNAMEs unproxied.
 
 ---
 
 ## 5) Verify with dig (propagation & correctness)
 
-Check CAA on the host you’re certifying (`www`):
-    dig CAA <www.uncommonengineer.com> +short
+Check CAA on the host you're certifying (`www`):
+
+```bash
+dig CAA www.uncommonengineer.com +short
+```
 
 Expected lines after propagation:
-    0 issuewild "letsencrypt.org"
-    0 issuewild "pki.goog"
+
+```text
+0 issuewild "letsencrypt.org"
+0 issuewild "pki.goog"
+```
 
 Check the SendGrid CNAMEs:
-    dig CNAME elinkb04.www.uncommonengineer.com +short
-    dig CNAME 55963338.www.uncommonengineer.com +short
+
+```bash
+dig CNAME elinkb04.www.uncommonengineer.com +short
+dig CNAME 55963338.www.uncommonengineer.com +short
+```
 
 Expected:
-    sendgrid.net.
-    sendgrid.net.
+
+```text
+sendgrid.net.
+sendgrid.net.
+```
 
 Check from multiple resolvers if needed:
-    dig @1.1.1.1 CAA <www.uncommonengineer.com> +short
-    dig @8.8.8.8 CAA <www.uncommonengineer.com> +short
+
+```bash
+dig @1.1.1.1 CAA www.uncommonengineer.com +short
+dig @8.8.8.8 CAA www.uncommonengineer.com +short
+```
 
 Also check the apex, which can override if it has CAA:
-    dig CAA uncommonengineer.com +short
+
+```bash
+dig CAA uncommonengineer.com +short
+```
 
 If your apex returns restrictive CAA (e.g., only digicert.com), either remove that restriction or add matching `issue`/`issuewild` for `letsencrypt.org` and `pki.goog` at the apex as well (CAs walk up the tree: closest CAA set wins).
 
@@ -134,8 +152,8 @@ If your apex returns restrictive CAA (e.g., only digicert.com), either remove th
 ## 6) Troubleshooting checklist
 
 - CNAMEs are grey-clouded (DNS-only), not proxied.
-- CAA Tag is correct (“Only allow wildcards” → `issuewild`).
-- CA domains are exactly `letsencrypt.org` and `pki.goog` (no prefixed “0 issuewild” text in the field).
+- CAA Tag is correct ("Only allow wildcards" → `issuewild`).
+- CA domains are exactly `letsencrypt.org` and `pki.goog` (no prefixed "0 issuewild" text in the field).
 - No conflicting CAA at the apex blocking issuance. If apex has CAA, mirror the authorizations there.
 - Wait for DNS propagation (often minutes, can be longer). Re-run dig until expected values appear.
 - Clear any cached/failed verification attempts in Beehiiv and retry the domain connection.
@@ -146,33 +164,35 @@ If your apex returns restrictive CAA (e.g., only digicert.com), either remove th
 
 Run this from a Linux terminal; replace names if your IDs differ.
 
-    #!/usr/bin/env bash
-    set -euo pipefail
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-    DOMAIN="uncommonengineer.com"
-    HOST="www.${DOMAIN}"
+DOMAIN="uncommonengineer.com"
+HOST="www.${DOMAIN}"
 
-    echo "== CAA on ${HOST} =="
-    dig CAA "${HOST}" +short
+echo "== CAA on ${HOST} =="
+dig CAA "${HOST}" +short
 
-    echo
-    echo "== CAA on apex ${DOMAIN} =="
-    dig CAA "${DOMAIN}" +short
+echo
+echo "== CAA on apex ${DOMAIN} =="
+dig CAA "${DOMAIN}" +short
 
-    echo
-    echo "== SendGrid CNAMEs =="
-    for SUB in "elinkb04.www" "55963338.www"; do
-      FQDN="${SUB}.${DOMAIN}"
-      printf "%s -> " "${FQDN}"
-      dig CNAME "${FQDN}" +short
-    done
+echo
+echo "== SendGrid CNAMEs =="
+for SUB in "elinkb04.www" "55963338.www"; do
+  FQDN="${SUB}.${DOMAIN}"
+  printf "%s -> " "${FQDN}"
+  dig CNAME "${FQDN}" +short
+done
 
-    echo
-    echo "== Cross-check via public resolvers (1.1.1.1, 8.8.8.8) =="
-    for R in 1.1.1.1 8.8.8.8; do
-      echo "@${R} CAA ${HOST}"
-      dig @"${R}" CAA "${HOST}" +short
-    done
+echo
+echo "== Cross-check via public resolvers (1.1.1.1, 8.8.8.8) =="
+for R in 1.1.1.1 8.8.8.8; do
+  echo "@${R} CAA ${HOST}"
+  dig @"${R}" CAA "${HOST}" +short
+done
+```
 
 ---
 
@@ -180,9 +200,7 @@ Run this from a Linux terminal; replace names if your IDs differ.
 
 - Add Beehiiv/SendGrid CNAMEs at the exact names provided and keep them **DNS-only**.
 - Add `CAA` at `www` with `issuewild` for `letsencrypt.org` and `pki.goog`.
-- Ensure the apex doesn’t contradict your `www` CAA policy.
+- Ensure the apex doesn't contradict your `www` CAA policy.
 - Validate with `dig`; then retry Beehiiv verification.
 
 Once verified, you can focus on writing — the DNS will stay out of your way.
-
-```


### PR DESCRIPTION
An unclosed code fence caused sections 3–8 to render as one giant code block. Closes the DNS records fence, wraps dig commands and script in proper fenced blocks, and updates the changelog.

Made-with: Cursor