### PR TITLE
fix: increase spacing between hackathon partner logos

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -280,11 +280,11 @@ p {
 .hackathon-partners {
   display: flex;
   flex-wrap: wrap;
-  gap: 2rem;
+  gap: 4rem;
   align-items: center;
-  justify-content: center;
+  justify-content: space-around;
   margin: 1.5rem 0 2rem;
-  padding: 1.5rem 1rem;
+  padding: 2rem 2.5rem;
   background: #ffffff;
   border-radius: 12px;
   border: 1px solid rgba(255, 255, 255, 0.08);
@@ -304,6 +304,11 @@ p {
 }
 
 @media screen and (max-width: 600px) {
+  .hackathon-partners {
+    gap: 2rem;
+    padding: 1.5rem 1rem;
+  }
+
   .hackathon-partners img {
     max-height: 48px;
     max-width: 160px;


### PR DESCRIPTION
## Summary

Gives the partner logos on the Hackathon landing page more breathing room.

## Changes

- `.hackathon-partners`: gap bumped from `2rem` to `4rem`, `justify-content` switched to `space-around`, padding increased to `2rem 2.5rem`.
- Mobile override (<600px) keeps the original tighter `2rem` gap and `1.5rem 1rem` padding so logos don't crowd or overflow on small screens.

## Tested

- Visual change only — no build/lint impact.