### PR TITLE
Homepage, docs landing, and newsletter CTA refresh

### DIFF
--- a/website/changelog/2026/july.md
+++ b/website/changelog/2026/july.md
@@ -9,6 +9,8 @@ description: Changes and additions for July 2026
 ## 📅 2026-07-04
 
 ### 🎨 Design Changes
+- **Newsletter copy refresh**: Unified positioning across site — "the how vs the what" framing with Pasifika lens, Big Tech, and no-filter fortnightly cadence; context-specific openers on doc footers ("The docs are the how"), blog footers ("This essay"), and Start Here ("The guides"); pitch segments support bold/emphasis formatting via shared `NewsletterPitch` component
+- **Doc footer newsletter CTA**: Warm gold accent card with checkmark badge and button-style subscribe link; lead line reads "Enjoying the docs? Good."
 - **Homepage cards**: Larger section emojis; featured essay on the Analysis card is now a direct link to the flagship post
 - **Announcement bar**: Red brand background with white copy and high-contrast black subscribe link — replaces the default white bar on the dark theme
 

--- a/website/changelog/2026/july.md
+++ b/website/changelog/2026/july.md
@@ -6,6 +6,16 @@ description: Changes and additions for July 2026
 
 # July 2026
 
+## 📅 2026-07-04
+
+### 🎨 Design Changes
+- **Homepage cards**: Larger section emojis; featured essay on the Analysis card is now a direct link to the flagship post
+- **Announcement bar**: Red brand background with white copy and high-contrast black subscribe link — replaces the default white bar on the dark theme
+
+### 🛠️ Site Improvements
+- **Technical landing page (`/docs/`)**: Removed misleading “Recently Updated” block (file mtime, mostly stale study notes); fixed “Where to Start” pathway cards that 404’d (`/docs/engineer`, `/docs/study`); replaced Study pathway with AI Projects hub; moved Study and Books & Papers to the bottom of the docs sidebar
+  - **Link**: [Start Here](/docs/)
+
 ## 📅 2026-07-03
 
 ### 🛠️ Site Improvements

--- a/website/docs/books/_category_.json
+++ b/website/docs/books/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "📚 Books & Papers",
-  "position": 2
+  "position": 9
 }

--- a/website/docs/start-here.mdx
+++ b/website/docs/start-here.mdx
@@ -6,7 +6,7 @@ sidebar_position: 1
 hide_title: true
 ---
 
-import { Hero, SiteStats, CuratedStartHere, RecentPosts, RecentDocs, Pathways, NewsletterCapture } from '@site/src/components/StartHere';
+import { Hero, SiteStats, CuratedStartHere, RecentPosts, Pathways, NewsletterCapture } from '@site/src/components/StartHere';
 
 <Hero />
 
@@ -15,8 +15,6 @@ import { Hero, SiteStats, CuratedStartHere, RecentPosts, RecentDocs, Pathways, N
 <CuratedStartHere />
 
 <RecentPosts />
-
-<RecentDocs />
 
 ## Where to Start
 

--- a/website/docs/study/_category_.json
+++ b/website/docs/study/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "📗 Study",
-  "position": 2
+  "position": 8
 }

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -62,7 +62,7 @@ module.exports = {
 
   themeConfig: {
     announcementBar: {
-      id: 'newsletter-2026-07-v2',
+      id: 'newsletter-2026-07-v3',
       content: ANNOUNCEMENT_BAR_HTML,
       isCloseable: true,
     },

--- a/website/src/components/NewsletterPitch/index.js
+++ b/website/src/components/NewsletterPitch/index.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import {
+  NEWSLETTER_CONTEXT_PREFIXES,
+  NEWSLETTER_PITCH_SEGMENTS,
+} from '@site/src/data/siteConstants';
+import styles from './styles.module.css';
+
+/**
+ * Formatted newsletter pitch — use anywhere React renders the copy.
+ * @param {'doc'|'blog'|'startHere'} [context] — optional "the how" opener
+ */
+export default function NewsletterPitch({
+  context,
+  className,
+  punchlineClassName,
+  taglineClassName,
+}) {
+  const { setup, punchline, body, tagline } = NEWSLETTER_PITCH_SEGMENTS;
+  const prefix = context ? NEWSLETTER_CONTEXT_PREFIXES[context] : null;
+
+  return (
+    <span className={className}>
+      {prefix && (
+        <>
+          {prefix.subject} <strong>{prefix.contrast}</strong>.{' '}
+        </>
+      )}
+      {setup}
+      <strong className={punchlineClassName || styles.punchline}>{punchline}</strong>
+      {body}{' '}
+      <em className={taglineClassName || styles.tagline}>{tagline}</em>
+    </span>
+  );
+}

--- a/website/src/components/NewsletterPitch/styles.module.css
+++ b/website/src/components/NewsletterPitch/styles.module.css
@@ -1,0 +1,10 @@
+.punchline {
+  color: inherit;
+  font-weight: 800;
+}
+
+.tagline {
+  font-style: normal;
+  font-weight: 600;
+  opacity: 0.9;
+}

--- a/website/src/components/StartHere/index.js
+++ b/website/src/components/StartHere/index.js
@@ -2,9 +2,9 @@ import React from 'react';
 import Link from '@docusaurus/Link';
 import { usePluginData } from '@docusaurus/useGlobalData';
 import BeehiivEmbed from '@site/src/components/BeehiivEmbed';
+import NewsletterPitch from '@site/src/components/NewsletterPitch';
 import {
   CURATED_START_HERE,
-  NEWSLETTER_DESCRIPTION,
   NEWSLETTER_OBJECTION,
 } from '@site/src/data/siteConstants';
 import styles from './styles.module.css';
@@ -172,7 +172,9 @@ export function RecentDocs() {
 export function NewsletterCapture() {
   return (
     <div className={styles.newsletterSection}>
-      <p className={styles.newsletterDescription}>{NEWSLETTER_DESCRIPTION}</p>
+      <p className={styles.newsletterDescription}>
+        <NewsletterPitch context="startHere" />
+      </p>
       <p className={styles.newsletterObjection}>{NEWSLETTER_OBJECTION}</p>
       <BeehiivEmbed utmSource="site" utmMedium="start" height={160} />
     </div>

--- a/website/src/components/StartHere/index.js
+++ b/website/src/components/StartHere/index.js
@@ -104,25 +104,25 @@ export function Pathways() {
       label: 'Engineer',
       title: 'Cloud & Infrastructure',
       desc: 'AWS, Kubernetes, AI, security, and architecture projects.',
-      to: '/docs/engineer',
+      to: '/docs/engineer/LAB/',
     },
     {
       label: 'Essays',
       title: 'Analysis & Essays',
       desc: 'AI sovereignty, digital colonialism, Pacific identity.',
-      to: '/blog',
+      to: '/blog/',
     },
     {
-      label: 'Certifications',
-      title: 'Study Notes',
-      desc: 'CKA, CKS, AWS SA Pro — exam prep and walkthroughs.',
-      to: '/docs/study',
+      label: 'AI',
+      title: 'AI & ML Projects',
+      desc: 'LLM deployment, Bedrock, private AI, and agentic RAG.',
+      to: '/docs/engineer/AI/',
     },
     {
       label: 'Homelab',
       title: 'Proxmox Hub',
       desc: 'The complete guide collection for Proxmox virtualization.',
-      to: '/docs/engineer/LAB/proxmox-hub',
+      to: '/docs/engineer/LAB/proxmox-hub/',
     },
   ];
 

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -71,6 +71,17 @@ div[class*='announcementBarContent'] a:hover {
   text-decoration: underline;
 }
 
+div[class*='announcementBarContent'] strong {
+  color: #fff;
+  font-weight: 800;
+}
+
+div[class*='announcementBarContent'] em {
+  font-style: normal;
+  font-weight: 600;
+  opacity: 0.92;
+}
+
 button[class*='announcementBarClose'] {
   color: #F5F3F4;
   opacity: 0.85;

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -45,24 +45,40 @@ html[data-theme='dark'] {
   padding: 0 var(--ifm-pre-padding);
 }
 
-/* Announcement bar — thin, no animation */
+/* Announcement bar — brand red, high contrast on dark site */
 div[class*='announcementBar'] {
+  --docusaurus-announcement-bar-background-color: var(--ifm-color-primary);
+  background-color: var(--ifm-color-primary) !important;
+  color: #F5F3F4;
   font-size: 0.85rem;
   line-height: 1.4;
 }
 
 div[class*='announcementBarContent'] {
   padding: 0.35rem 0;
+  color: #F5F3F4;
 }
 
 div[class*='announcementBarContent'] a {
-  color: var(--ifm-color-primary);
-  font-weight: 600;
-  text-decoration: none;
+  color: #0B090A;
+  font-weight: 700;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 div[class*='announcementBarContent'] a:hover {
+  color: #161A1D;
   text-decoration: underline;
+}
+
+button[class*='announcementBarClose'] {
+  color: #F5F3F4;
+  opacity: 0.85;
+}
+
+button[class*='announcementBarClose']:hover {
+  color: #fff;
+  opacity: 1;
 }
 
 /* Enable word wrapping in code blocks */

--- a/website/src/data/geoContent.js
+++ b/website/src/data/geoContent.js
@@ -195,7 +195,7 @@ export function buildLlmsTxt() {
     ...TOP_GUIDES.map((e) => `- [${e.title}](${SITE_URL}${e.path}): ${e.description}`),
     '',
     '## Newsletter',
-    `- [The Uncommon Engineer Newsletter](${SITE_URL}/newsletter/): Fortnightly — AI, power, and tech from inside the machine.`,
+    `- [The Uncommon Engineer Newsletter](${SITE_URL}/newsletter/): The what, not the how — AI, power, Big Tech, Pasifika lens. Fortnightly. No filter.`,
   ];
 
   return `${lines.join('\n')}\n`;

--- a/website/src/data/siteConstants.js
+++ b/website/src/data/siteConstants.js
@@ -33,14 +33,49 @@ export const LINKEDIN_POST_CTA_STRINGS = [
   `Fortnightly from inside the machine → ${LINKEDIN_NEWSLETTER_URLS.post}`,
 ];
 
-export const NEWSLETTER_DESCRIPTION =
-  'Unfiltered takes on AI, power, and tech from a Pasifika engineer twenty-plus years inside the machine. No polish. Fortnightly.';
+/** Core newsletter pitch — edit segments here; formatting via NewsletterPitch component. */
+export const NEWSLETTER_PITCH_SEGMENTS = {
+  setup: 'The newsletter is the what... as in, ',
+  punchline: 'what the f***',
+  body: " — AI, power, Big Tech and the tech industry, through a Pasifika lens, from an engineer who's spent twenty-plus years working inside the machine.",
+  tagline: 'Fortnightly. No filter.',
+};
 
-export const NEWSLETTER_OBJECTION = 'One email a fortnight. Leave whenever.';
+/** Context openers paired with the pitch ("…the how."). */
+export const NEWSLETTER_CONTEXT_PREFIXES = {
+  doc: { subject: 'The docs are', contrast: 'the how' },
+  blog: { subject: 'This essay is', contrast: 'the how' },
+  startHere: { subject: 'The guides are', contrast: 'the how' },
+};
 
-/** Site-wide announcement bar — keep in sync with newsletter positioning. */
+function buildNewsletterPitchPlain(context) {
+  const { setup, punchline, body, tagline } = NEWSLETTER_PITCH_SEGMENTS;
+  const pitch = `${setup}${punchline}${body} ${tagline}`;
+
+  if (!context) {
+    return pitch;
+  }
+
+  const { subject, contrast } = NEWSLETTER_CONTEXT_PREFIXES[context];
+  return `${subject} ${contrast}. ${pitch}`;
+}
+
+/** Plain text for meta tags, SEO, llms.txt, and other non-React surfaces. */
+export const NEWSLETTER_PITCH = buildNewsletterPitchPlain();
+
+/** Default description for homepage card, /newsletter page, and meta tags. */
+export const NEWSLETTER_DESCRIPTION = NEWSLETTER_PITCH;
+
+/** Plain-text variants (legacy exports — prefer NewsletterPitch component in UI). */
+export const NEWSLETTER_DOC_FOOTER_BODY = buildNewsletterPitchPlain('doc');
+export const NEWSLETTER_BLOG_FOOTER_BODY = buildNewsletterPitchPlain('blog');
+export const NEWSLETTER_START_HERE_BODY = buildNewsletterPitchPlain('startHere');
+
+export const NEWSLETTER_OBJECTION = 'Leave whenever.';
+
+/** Site-wide announcement bar — HTML allowed; keep plain-text meaning in sync with segments. */
 export const ANNOUNCEMENT_BAR_HTML =
-  'Unfiltered takes on AI, power, and tech — fortnightly from inside the machine. <a href="/newsletter?utm_source=site&utm_medium=banner">Subscribe →</a>';
+  'The <strong>what</strong>, not the <strong>how</strong> — AI, power, Big Tech, Pasifika lens. <em>Fortnightly. No filter.</em> <a href="/newsletter?utm_source=site&utm_medium=banner">Subscribe →</a>';
 
 export const HOMEPAGE_TITLE =
   'Engineering Guides, AI Sovereignty & Pacific Tech | The Uncommon Engineer';

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -4,6 +4,7 @@ import Layout from '@theme/Layout';
 import Head from '@docusaurus/Head';
 import { usePluginData } from '@docusaurus/useGlobalData';
 import BeehiivEmbed from '@site/src/components/BeehiivEmbed';
+import NewsletterPitch from '@site/src/components/NewsletterPitch';
 import {
   FLAGSHIP_ESSAY,
   HOMEPAGE_TITLE,
@@ -69,7 +70,12 @@ function NewsletterCard() {
         <span className={styles.cardIcon}>📬</span>
       </div>
       <h3 className={styles.cardTitle}>Newsletter</h3>
-      <p className={styles.cardDescription}>{NEWSLETTER_DESCRIPTION}</p>
+      <p className={styles.cardDescription}>
+        <NewsletterPitch
+          punchlineClassName={styles.newsletterPunchline}
+          taglineClassName={styles.newsletterTagline}
+        />
+      </p>
       <BeehiivEmbed utmSource="site" utmMedium="home" variant="compact" />
     </div>
   );

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -24,26 +24,41 @@ function trackCardClick(cardName, destination) {
   }
 }
 
-function ContentCard({ icon, title, count, countLabel, description, linkText, linkTo, latestLabel }) {
+function ContentCard({ icon, title, count, countLabel, description, linkText, linkTo, featured }) {
   return (
-    <Link
-      className={styles.card}
-      to={linkTo}
-      onClick={() => trackCardClick(title, linkTo)}
-    >
+    <div className={styles.card}>
       <div className={styles.cardHeader}>
-        <span className={styles.cardIcon}>{icon}</span>
+        <span className={styles.cardIcon} aria-hidden="true">{icon}</span>
         <span className={styles.cardCount}>{count}+ {countLabel}</span>
       </div>
-      <h3 className={styles.cardTitle}>{title}</h3>
-      <p className={styles.cardDescription}>{description}</p>
-      {latestLabel && (
-        <p className={styles.latestPost}>Featured: {latestLabel}</p>
+      <Link
+        className={styles.cardBodyLink}
+        to={linkTo}
+        onClick={() => trackCardClick(title, linkTo)}
+      >
+        <h3 className={styles.cardTitle}>{title}</h3>
+        <p className={styles.cardDescription}>{description}</p>
+      </Link>
+      {featured && (
+        <p className={styles.latestPost}>
+          Featured:{' '}
+          <Link
+            to={featured.to}
+            className={styles.featuredLink}
+            onClick={() => trackCardClick(`${title} — featured`, featured.to)}
+          >
+            {featured.title}
+          </Link>
+        </p>
       )}
-      <span className={styles.cardLink}>
+      <Link
+        className={styles.cardLink}
+        to={linkTo}
+        onClick={() => trackCardClick(title, linkTo)}
+      >
         {linkText} <span className={styles.arrow}>→</span>
-      </span>
-    </Link>
+      </Link>
+    </div>
   );
 }
 
@@ -140,7 +155,7 @@ function Home() {
               description="Deep-dive essays exploring how technology intersects with power, sovereignty, and Pacific identity."
               linkText="Browse Analysis"
               linkTo="/blog/"
-              latestLabel={FLAGSHIP_ESSAY.title}
+              featured={FLAGSHIP_ESSAY}
             />
 
             <ContentCard

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -262,7 +262,6 @@
   border: 1px solid #2a2a2a;
   border-radius: 12px;
   padding: 1.5rem;
-  text-decoration: none;
   color: inherit;
   transition: all 0.25s ease;
   display: flex;
@@ -273,6 +272,16 @@
   border-color: var(--ifm-color-primary);
   box-shadow: 0 0 30px rgba(164, 22, 26, 0.15);
   transform: translateY(-3px);
+}
+
+.cardBodyLink {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  flex: 1;
+}
+
+.cardBodyLink:hover {
   text-decoration: none;
   color: inherit;
 }
@@ -285,7 +294,8 @@
 }
 
 .cardIcon {
-  font-size: 1.25rem;
+  font-size: 2rem;
+  line-height: 1;
 }
 
 .cardCount {
@@ -320,6 +330,18 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.featuredLink {
+  color: var(--ifm-color-primary);
+  font-style: normal;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.featuredLink:hover {
+  text-decoration: underline;
+  color: var(--ifm-color-primary-light);
 }
 
 .cardLink {

--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -209,6 +209,17 @@
   margin-bottom: 0.5rem;
 }
 
+.newsletterPunchline {
+  color: #f0c75e;
+  font-weight: 800;
+}
+
+.newsletterTagline {
+  font-style: normal;
+  font-weight: 600;
+  color: #b0b0b0;
+}
+
 .heroCta {
   display: inline-flex;
   align-items: center;

--- a/website/src/pages/newsletter/index.js
+++ b/website/src/pages/newsletter/index.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import Layout from '@theme/Layout';
 import BeehiivEmbed from '@site/src/components/BeehiivEmbed';
+import NewsletterPitch from '@site/src/components/NewsletterPitch';
 import {
   NEWSLETTER_DESCRIPTION,
   NEWSLETTER_OBJECTION,
@@ -68,7 +69,9 @@ function Newsletter() {
       <main className={styles.newsletterPage}>
         <div className={styles.newsletterContainer}>
           <h1 className={styles.title}>The Uncommon Engineer</h1>
-          <p className={styles.body}>{NEWSLETTER_DESCRIPTION}</p>
+          <p className={styles.body}>
+            <NewsletterPitch />
+          </p>
           <p className={styles.objection}>{NEWSLETTER_OBJECTION}</p>
 
           {embedUtms && (

--- a/website/src/theme/BlogPostItem/index.js
+++ b/website/src/theme/BlogPostItem/index.js
@@ -3,6 +3,8 @@ import BlogPostItem from '@theme-original/BlogPostItem';
 import {useBlogPost} from '@docusaurus/plugin-content-blog/client';
 import {BlogPostingSchema} from '@site/src/components/StructuredData';
 import {SITE_URL} from '@site/src/data/geoContent';
+import NewsletterPitch from '@site/src/components/NewsletterPitch';
+import { NEWSLETTER_OBJECTION } from '@site/src/data/siteConstants';
 import styles from './styles.module.css';
 
 function toAbsoluteUrl(path) {
@@ -27,8 +29,9 @@ function NewsletterCta() {
       <span className={styles.emoji}>✉️</span>
       <div className={styles.ctaContent}>
         <p className={styles.ctaText}>
-          Want posts like this straight in your inbox every fortnight?
+          <NewsletterPitch context="blog" />
         </p>
+        <p className={styles.ctaObjection}>{NEWSLETTER_OBJECTION}</p>
         <a
           href="/newsletter?utm_source=site&utm_medium=blog"
           className={styles.ctaButton}

--- a/website/src/theme/BlogPostItem/styles.module.css
+++ b/website/src/theme/BlogPostItem/styles.module.css
@@ -38,6 +38,24 @@
   line-height: 1.6;
 }
 
+.ctaText strong {
+  color: var(--ifm-color-primary-light);
+  font-weight: 800;
+}
+
+.ctaText em {
+  font-style: normal;
+  font-weight: 600;
+  color: #999;
+}
+
+.ctaObjection {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #888;
+  line-height: 1.5;
+}
+
 .ctaButton {
   display: inline-block;
   width: fit-content;

--- a/website/src/theme/DocItem/Footer/index.js
+++ b/website/src/theme/DocItem/Footer/index.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import Footer from '@theme-original/DocItem/Footer';
+import NewsletterPitch from '@site/src/components/NewsletterPitch';
+import { NEWSLETTER_OBJECTION } from '@site/src/data/siteConstants';
 import styles from './styles.module.css';
 
 function trackNewsletterCtaClick() {
@@ -17,22 +19,27 @@ export default function FooterWrapper(props) {
     <>
       <Footer {...props} />
       <div className={styles.newsletterCta}>
-        <p className={styles.lead}>
-          <strong>This guide worked? Good.</strong>
-        </p>
-        <p>
-          I write like this every fortnight — AI, infra, security. What worked,
-          what broke, what the marketing didn&apos;t mention. No polish, no hype.
-          One email a fortnight. Leave whenever.
-        </p>
-        <p>
+        <span className={styles.emoji} aria-hidden="true">✓</span>
+        <div className={styles.ctaContent}>
+          <p className={styles.lead}>
+            <strong>Enjoying the docs? Good.</strong>
+          </p>
+          <p className={styles.body}>
+            <NewsletterPitch
+              context="doc"
+              punchlineClassName={styles.punchline}
+              taglineClassName={styles.tagline}
+            />
+          </p>
+          <p className={styles.objection}>{NEWSLETTER_OBJECTION}</p>
           <a
+            className={styles.ctaButton}
             href="/newsletter?utm_source=site&utm_medium=guide"
             onClick={trackNewsletterCtaClick}
           >
             Get the newsletter →
           </a>
-        </p>
+        </div>
       </div>
     </>
   );

--- a/website/src/theme/DocItem/Footer/styles.module.css
+++ b/website/src/theme/DocItem/Footer/styles.module.css
@@ -1,32 +1,96 @@
 .newsletterCta {
+  display: flex;
+  align-items: flex-start;
+  gap: 1.1rem;
   margin-top: 2.5rem;
-  padding: 1.25rem 1.5rem;
-  border-radius: 8px;
-  border: 1px solid #2a2a2a;
-  background-color: #161A1D;
+  padding: 1.5rem 1.75rem;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #2a2208 0%, #1a1505 55%, #141108 100%);
+  border: 1px solid rgba(212, 168, 67, 0.4);
+  border-left: 5px solid #d4a843;
+  box-shadow:
+    0 4px 28px rgba(212, 168, 67, 0.14),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
 }
 
-.newsletterCta p {
-  margin: 0 0 0.75rem;
-  font-size: 0.95rem;
-  color: var(--ifm-font-color-base);
-  line-height: 1.6;
+.emoji {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  margin-top: 0.1rem;
+  font-size: 1.25rem;
+  font-weight: 800;
+  line-height: 1;
+  color: #1a1205;
+  background: linear-gradient(180deg, #f0c75e 0%, #d4a843 100%);
+  border-radius: 50%;
+  box-shadow: 0 2px 8px rgba(212, 168, 67, 0.35);
 }
 
-.newsletterCta p:last-child {
-  margin-bottom: 0;
+.ctaContent {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  min-width: 0;
 }
 
 .lead {
-  margin-bottom: 0.5rem !important;
+  margin: 0;
 }
 
-.newsletterCta a {
-  color: var(--ifm-color-primary);
+.lead strong {
+  font-size: 1.1rem;
+  color: #f0c75e;
+  letter-spacing: -0.01em;
+}
+
+.body {
+  margin: 0;
+  font-size: 0.92rem;
+  color: #d8ccb4;
+  line-height: 1.6;
+}
+
+.punchline {
+  color: #f0c75e;
+  font-weight: 800;
+}
+
+.tagline {
+  color: #e8b84a;
+  font-style: normal;
   font-weight: 600;
-  text-decoration: none;
 }
 
-.newsletterCta a:hover {
-  text-decoration: underline;
+.objection {
+  margin: 0;
+  font-size: 0.82rem;
+  color: #a89878;
+  line-height: 1.5;
+}
+
+.ctaButton {
+  display: inline-block;
+  width: fit-content;
+  margin-top: 0.25rem;
+  padding: 0.55rem 1.35rem;
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: #1a1205;
+  background: linear-gradient(180deg, #f0c75e 0%, #c9932a 100%);
+  border-radius: 6px;
+  text-decoration: none;
+  box-shadow: 0 2px 10px rgba(201, 147, 42, 0.35);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
+}
+
+.ctaButton:hover {
+  color: #0b090a;
+  text-decoration: none;
+  transform: translateY(-1px);
+  filter: brightness(1.06);
+  box-shadow: 0 4px 16px rgba(201, 147, 42, 0.45);
 }


### PR DESCRIPTION
## Summary
- Homepage cards: larger emojis, linkable featured essay, red announcement bar aligned to brand
- Docs landing (`/docs/`): removed misleading Recently Updated block, fixed Where to Start 404s, demoted Study/Books in sidebar
- Newsletter positioning: unified "the how vs the what" copy via `NewsletterPitch` component with formatted segments across docs, blog, homepage, Start Here, and announcement bar
- Doc footer CTA: gold accent card with "Enjoying the docs? Good." lead and button-style subscribe link

## Test plan
- [ ] Homepage: card emojis, featured essay link, newsletter card formatting, announcement bar styling
- [ ] `/docs/`: pathway links resolve, no Recently Updated section, newsletter block copy
- [ ] Any doc page: gold footer CTA renders with formatted pitch and working subscribe link
- [ ] Any blog post: footer CTA shows essay context copy
- [ ] `/newsletter/`: pitch renders with emphasis styling
- [ ] `npm run build` succeeds


Made with [Cursor](https://cursor.com)