### PR TITLE
about: adopt full M4 bio from messaging kit v2

### DIFF
--- a/website/src/pages/about/index.js
+++ b/website/src/pages/about/index.js
@@ -29,14 +29,20 @@ function About() {
                 I'm Ali'imuamua Ron Amosa — <strong>The Uncommon Engineer</strong>.
                 </p>
                 <p>
-                I'm a Pasifika technologist of Samoan, Tuvaluan, and Chinese heritage. For more than two decades I've worked across SRE, cyber security, and solution architecture. Today I'm a Senior Solutions Architect at AWS, focused on AI, containers, Kubernetes, and cloud security — the full stack from infrastructure and code, through risk, governance, and business outcomes.
+                I build infrastructure for the empire. I also see exactly how it breaks, from the inside.
+                </p>
+                <p>
+                I'm a Pasifika technologist with over two decades building, securing, and scaling systems across SRE, security engineering, and solution architecture. As a contract Senior SRE, I designed and delivered full dev-test-prod platforms on Kubernetes across AWS, Azure, and GCP for banks and insurers. I assessed platforms at Salesforce, Heroku, and Mulesoft as a Senior Security Engineer. Today I'm the first and only Senior Partner Solutions Architect for the Pacific at AWS, working at the intersection of technical depth and enterprise-scale delivery — AI, containers, and cloud security.
+                </p>
+                <p>
+                Beyond Big Tech, I founded the Pasifika Tech Education Charity in 2019, consult with Pasifika community groups across Auckland, and support Māori-led initiatives. The work bridges technical depth and adversarial awareness with community impact — writing, speaking, and building toward technology that serves the people, not serves them up to the tech overlords.
                 </p>
                 <h3>This site is my working lab book.</h3>
                 <p>
                 It's where I document experiments, random projects, lab builds, hacking walk-throughs, hard-won technical lessons, things I'm still figuring out, and thoughts on the tech industry, which is usually part of my newsletter.
                 </p>
                 <p>
-                Outside of work, I'm a husband and father, a BJJ black belt, drummer, and a tattoo and motorcycle enthusiast.
+                A proud Samoan, Tuvaluan, and Chinese New Zealander. Husband, father, BJJ black belt, drummer, and a tattoo and motorcycle enthusiast.
                 </p>
                 <div className={styles.socialIcons}>
                   <a href="https://www.linkedin.com/in/ron-amosa/" target="_blank" rel="noopener noreferrer" className={styles.socialIcon}>


### PR DESCRIPTION
Deploys checklist #16 — the FULL M4 About copy from messaging kit v2.

**Change**
- `/about` bio replaced with canonical FULL M4 (three paragraphs: the 'infrastructure for the empire' hook, the two-decade SRE→security→SA arc ending on *first and only Senior Partner Solutions Architect for the Pacific at AWS*, and the community/charity line).
- Personal tail set to the website-specific line (drummer + tattoo/motorcycle enthusiast).
- Kept: the 'Talofa / Ali'imuamua Ron Amosa' intro and the 'This site is my working lab book' section (site-purpose content M4 doesn't cover).

**Not in this PR**
- Checklist #19 (dead `x.com/uncommonengneer` link) left untouched — needs the correct handle or a remove decision.

Copy is FINAL per the messaging kit. Deploy via normal build.