### PR TITLE
feat: add /tn TechNesians Discord redirect

### DIFF
--- a/website/changelog/2026/july.md
+++ b/website/changelog/2026/july.md
@@ -6,6 +6,14 @@ description: Changes and additions for July 2026
 
 # July 2026
 
+## 📅 2026-07-15
+
+### 🛠️ Site Improvements
+- **TechNesians Discord redirect (`/tn`)**: Added static `static/tn/index.html` landing that fires a GA4 `page_view` (reading `utm_*` off the URL) then bounces to the TechNesians Discord invite after ~500ms
+  - Single rotation point — the invite lives only in the `DEST` variable; `/tn` and any printed QR codes never change when the invite is rotated
+  - `noindex,nofollow`; uses the site GA4 Measurement ID (`G-DMRNTVGLRC`)
+  - **Link**: [/tn](/tn)
+
 ## 📅 2026-07-11
 
 ### 🛠️ Site Improvements

--- a/website/static/tn/index.html
+++ b/website/static/tn/index.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="noindex,nofollow">
+<title>Joining TechNesians…</title>
+
+<!-- ── EDIT THESE TWO THINGS ────────────────────────────────
+     1. INVITE  → your discord.gg invite code (one place, below)
+     2. GA4 ID  → your Measurement ID, appears TWICE (src + config)
+     ─────────────────────────────────────────────────────── -->
+
+<script>
+  // 1. Your Discord invite — the ONLY place the invite lives.
+  //    Rotate the code here + redeploy; /tn and your QR never change.
+  var DEST = "https://discord.gg/6hZqGXyjet";
+</script>
+
+<!-- 2. GA4 -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-DMRNTVGLRC"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){ dataLayer.push(arguments); }
+  gtag('js', new Date());
+
+  // page_view fires automatically and GA4 reads utm_* off this page's URL.
+  // sendBeacon keeps it alive through the redirect.
+  gtag('config', 'G-DMRNTVGLRC', { page_title: 'tn-redirect' });
+
+  // Bounce after GA has had its moment. ~500ms is invisible to the user
+  // and comfortably enough for the beacon to leave.
+  setTimeout(function(){ window.location.replace(DEST); }, 500);
+</script>
+</head>
+<body style="font-family:system-ui,-apple-system,sans-serif;background:#0b0b0b;color:#eaeaea;display:grid;place-items:center;height:100vh;margin:0">
+  <p style="opacity:.8">taking you to TechNesians…
+    <a id="fallback" href="#" style="color:#ff2fb9;text-decoration:none">click here if nothing happens</a>
+  </p>
+  <script>document.getElementById('fallback').href = DEST;</script>
+</body>
+</html>


### PR DESCRIPTION
## What

Adds a static redirect page at `static/tn/index.html`, served at `uncommonengineer.com/tn` (and `/tn/`), that bounces visitors to the TechNesians Discord invite while capturing GA4 analytics.

## How it works

- Fires a GA4 `page_view` (reading `utm_*` off the page URL, `sendBeacon` keeps it alive through the redirect), then `window.location.replace(DEST)` after ~500ms.
- **Single rotation point**: the Discord invite lives only in the `DEST` variable. `/tn` and any printed QR codes never change when the invite is rotated — just edit `DEST` and redeploy.
- `noindex,nofollow`; uses the site's existing GA4 Measurement ID (`G-DMRNTVGLRC`).
- Pure static — no React, plugin, or config. Docusaurus copies `static/` to the build root verbatim.

## Testing

After deploy, hit `uncommonengineer.com/tn?utm_source=test&utm_content=setup-check`:
- Confirm it lands in the TechNesians Discord.
- Check GA4 Realtime for the hit with `test` / `setup-check` as source/content.

Changelog updated (2026-07-15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)