### PR TITLE
fix: stop internal newsletter CTAs from polluting GA4 acquisition

### DIFF
--- a/website/blog/2026-07-03 - Pacific AI and Data Sovereignty.md
+++ b/website/blog/2026-07-03 - Pacific AI and Data Sovereignty.md
@@ -99,4 +99,4 @@ There is no neutral position on politics as a Pasifika person in tech. Apolitica
 ## Related
 
 - [Start Here](/docs/) — curated entry point for guides and essays
-- [The Uncommon Engineer Newsletter](/newsletter/?utm_source=site&utm_medium=guide) — fortnightly signal on AI, power, and tech
+- [The Uncommon Engineer Newsletter](/newsletter/?ref=guide) — fortnightly signal on AI, power, and tech

--- a/website/changelog/2026/july.md
+++ b/website/changelog/2026/july.md
@@ -8,6 +8,9 @@ description: Changes and additions for July 2026
 
 ## 📅 2026-07-23
 
+### 🛠️ Site Improvements
+- **Newsletter CTA attribution — stop polluting GA4 acquisition**: Internal newsletter CTAs (announcement bar, docs footer, blog footer, in-post links) previously used `?utm_source=site&utm_medium=<surface>`, which made GA4 start a fresh `site / <surface>` session on every click and fragmented the true acquisition source. Switched these to a non-utm `?ref=<surface>` param that GA4 ignores; the `/newsletter` page maps `ref` back into the Beehiiv subscribe UTMs (with a legacy `utm_medium` fallback), so signup attribution is unchanged while GA4 source/medium reporting is no longer diluted
+
 ### 🔧 Bug Fixes
 - **Chromebook guide slug typo**: Fixed the misspelled `chomebook-terminal` slug (missing `r`) — renamed to `chromebook-terminal` and added client-side redirects from both indexed typo paths (current `guides/` slug and the retired `Misc/` slug) to the corrected canonical URL, consolidating search authority onto one address
   - **Link**: [How to Enable Linux Terminal on Chromebook](/docs/engineer/guides/chromebook-terminal)

--- a/website/src/data/siteConstants.js
+++ b/website/src/data/siteConstants.js
@@ -75,7 +75,7 @@ export const NEWSLETTER_OBJECTION = 'Leave whenever.';
 
 /** Site-wide announcement bar — HTML allowed; keep plain-text meaning in sync with segments. */
 export const ANNOUNCEMENT_BAR_HTML =
-  'The <strong>what</strong>, not the <strong>how</strong> — AI, power, Big Tech, Pasifika lens. <em>Fortnightly. No filter.</em> <a href="/newsletter?utm_source=site&utm_medium=banner">Subscribe →</a>';
+  'The <strong>what</strong>, not the <strong>how</strong> — AI, power, Big Tech, Pasifika lens. <em>Fortnightly. No filter.</em> <a href="/newsletter?ref=banner">Subscribe →</a>';
 
 export const HOMEPAGE_TITLE =
   'Engineering Guides, AI Sovereignty & Pacific Tech | The Uncommon Engineer';

--- a/website/src/theme/BlogPostItem/index.js
+++ b/website/src/theme/BlogPostItem/index.js
@@ -33,7 +33,7 @@ function NewsletterCta() {
         </p>
         <p className={styles.ctaObjection}>{NEWSLETTER_OBJECTION}</p>
         <a
-          href="/newsletter?utm_source=site&utm_medium=blog"
+          href="/newsletter?ref=blog"
           className={styles.ctaButton}
           onClick={trackNewsletterCtaClick}
         >

--- a/website/src/theme/DocItem/Footer/index.js
+++ b/website/src/theme/DocItem/Footer/index.js
@@ -34,7 +34,7 @@ export default function FooterWrapper(props) {
           <p className={styles.objection}>{NEWSLETTER_OBJECTION}</p>
           <a
             className={styles.ctaButton}
-            href="/newsletter?utm_source=site&utm_medium=guide"
+            href="/newsletter?ref=guide"
             onClick={trackNewsletterCtaClick}
           >
             Get the newsletter →

--- a/website/src/utils/newsletterAttribution.js
+++ b/website/src/utils/newsletterAttribution.js
@@ -8,14 +8,24 @@ const DEFAULT_NEWSLETTER_EMBED_UTMS = {
 };
 
 /**
- * UTMs for the /newsletter page embed — forwards URL params from link hops
- * (guide footer, announcement bar, blog footer) before falling back to defaults.
+ * UTMs for the /newsletter page embed — forwards the internal surface into the
+ * Beehiiv subscribe attribution.
+ *
+ * Internal CTAs (announcement bar, guide footer, blog footer) pass the surface
+ * via a non-utm `ref` param on purpose: a `utm_*` param on an internal link
+ * makes GA4 start a fresh "site / <medium>" session on every click, fragmenting
+ * the true acquisition source. `ref` is invisible to GA4, so acquisition data
+ * stays intact while Beehiiv still gets source=site, medium=<surface>.
+ *
+ * `utm_medium` is still read as a fallback for legacy/shared links that predate
+ * the `ref` switch, and `utm_source` is honoured for real external inbound.
  */
 export function getNewsletterEmbedUtms(search = '') {
   const params = new URLSearchParams(search);
+  const surface = params.get('ref') || params.get('utm_medium');
   return {
     utmSource: params.get('utm_source') || DEFAULT_NEWSLETTER_EMBED_UTMS.utmSource,
-    utmMedium: params.get('utm_medium') || DEFAULT_NEWSLETTER_EMBED_UTMS.utmMedium,
+    utmMedium: surface || DEFAULT_NEWSLETTER_EMBED_UTMS.utmMedium,
   };
 }
 


### PR DESCRIPTION
## Summary

Addresses the inconsistent `site / blog|guide|banner` source/medium rows in GA4, and documents why the `(not set)` landing page is a separate GA4-config issue.

## Root cause (the `site / *` UTM noise)

The internal newsletter CTAs linked to `/newsletter?utm_source=site&utm_medium=<surface>`:

| Surface | File |
|---|---|
| `banner` | `src/data/siteConstants.js` (announcement bar) |
| `guide` | `src/theme/DocItem/Footer/index.js` |
| `blog` | `src/theme/BlogPostItem/index.js` |
| `guide` | in-post link in a blog essay |

`utm_*` on an **internal** link makes GA4 start a fresh `site / <surface>` session on every click — fragmenting the real acquisition source and creating the inconsistent rows you spotted. The UTMs only existed to forward the surface into the **Beehiiv** subscribe embed (`getNewsletterEmbedUtms`).

## Fix

- Internal links now use a **non-utm `?ref=<surface>`** param (GA4 ignores it).
- `getNewsletterEmbedUtms()` reads `ref` and maps it back into the Beehiiv UTMs (`source=site`, `medium=<surface>`), with `utm_medium` kept as a fallback for legacy/shared links.
- Real external inbound UTMs (LinkedIn hop, etc.) are untouched.

**Net:** Beehiiv signup attribution is identical; GA4 acquisition data is no longer diluted. Build verified passing.

## The `(not set)` landing page (842 sessions / 96% bounce) — *not* a code bug

I traced every gtag call. Nothing fires `page_view` without a resolvable path — the SPA plugin sends real page_views with `page_location`, and the custom client modules only emit *custom events* (which carry `page_path`). At that volume + 96% bounce, `(not set)` landing is the signature of:

1. **Bot / GA-spam** hitting the collect endpoint without executing the SPA router.
2. **By-design redirect bounces** — `/tn` (Discord) and the `/newsletter` LinkedIn hop both fire a page_view and immediately send the user off-site, so they're single-hit sessions.

These are GA4-side fixes, not repo changes:
- Confirm **Google signals / bot filtering** is on (GA4 auto-drops known bots, but not Measurement Protocol spam).
- Add a **hostname match** data filter / exploration segment (`hostname = uncommonengineer.com`) to drop ghost-referral spam.
- **Segment out** `/tn` and the LinkedIn-redirect page when judging content bounce — they bounce on purpose.

Happy to add a `noindex` + a distinct `page_title`/event tag to those redirect pages if you want them trivially filterable in GA4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)