### PR TITLE
chore: tag off-site redirect interstitials for GA4 filtering

### DIFF
--- a/website/changelog/2026/july.md
+++ b/website/changelog/2026/july.md
@@ -10,6 +10,7 @@ description: Changes and additions for July 2026
 
 ### 🛠️ Site Improvements
 - **Newsletter CTA attribution — stop polluting GA4 acquisition**: Internal newsletter CTAs (announcement bar, docs footer, blog footer, in-post links) previously used `?utm_source=site&utm_medium=<surface>`, which made GA4 start a fresh `site / <surface>` session on every click and fragmented the true acquisition source. Switched these to a non-utm `?ref=<surface>` param that GA4 ignores; the `/newsletter` page maps `ref` back into the Beehiiv subscribe UTMs (with a legacy `utm_medium` fallback), so signup attribution is unchanged while GA4 source/medium reporting is no longer diluted
+- **Tag off-site redirect interstitials for GA4 filtering**: The by-design redirect pages (`/tn` → Discord, `/newsletter/linkedin` and the LinkedIn-inbound `/newsletter` hop → hosted Beehiiv form) bounce users off-site instantly, inflating `(not set)`/high-bounce landing metrics. Each now fires a `redirect_interstitial` GA4 event (`event_category: redirect`) and carries a `Redirect — …` page title, so they can be excluded from content engagement/bounce analysis by event, page title, or path
 
 ### 🔧 Bug Fixes
 - **Chromebook guide slug typo**: Fixed the misspelled `chomebook-terminal` slug (missing `r`) — renamed to `chromebook-terminal` and added client-side redirects from both indexed typo paths (current `guides/` slug and the retired `Misc/` slug) to the corrected canonical URL, consolidating search authority onto one address

--- a/website/src/pages/newsletter/index.js
+++ b/website/src/pages/newsletter/index.js
@@ -31,6 +31,12 @@ function Newsletter() {
           referral_source: document.referrer || 'direct',
           attribution_medium: new URL(redirectUrl).searchParams.get('utm_medium'),
         });
+        // Consistent redirect tag so GA4 filtering can exclude this off-site
+        // interstitial from content engagement/bounce reports.
+        window.gtag('event', 'redirect_interstitial', {
+          event_category: 'redirect',
+          redirect_target: 'newsletter-linkedin-inbound',
+        });
       }
       window.location.replace(redirectUrl);
       return;
@@ -53,7 +59,7 @@ function Newsletter() {
 
   if (redirecting) {
     return (
-      <Layout title="The Uncommon Engineer" description={NEWSLETTER_DESCRIPTION}>
+      <Layout title="Redirect — Newsletter (LinkedIn)" description={NEWSLETTER_DESCRIPTION}>
         <main className={styles.newsletterPage}>
           <p className={styles.redirecting}>Redirecting to subscribe…</p>
         </main>

--- a/website/src/pages/newsletter/linkedin/index.js
+++ b/website/src/pages/newsletter/linkedin/index.js
@@ -14,12 +14,18 @@ export default function LinkedInNewsletterRedirect() {
         cta_surface: 'newsletter-linkedin-vanity',
         attribution_medium: 'post',
       });
+      // Consistent redirect tag so GA4 filtering can exclude this off-site
+      // interstitial from content engagement/bounce reports.
+      window.gtag('event', 'redirect_interstitial', {
+        event_category: 'redirect',
+        redirect_target: 'newsletter-linkedin-vanity',
+      });
     }
     window.location.replace(LINKEDIN_NEWSLETTER_URLS.post);
   }, []);
 
   return (
-    <Layout title="Subscribe" description="The Uncommon Engineer newsletter">
+    <Layout title="Redirect — Newsletter (LinkedIn)" description="The Uncommon Engineer newsletter">
       <main className={styles.newsletterPage}>
         <p className={styles.redirecting}>Redirecting to subscribe…</p>
       </main>

--- a/website/static/tn/index.html
+++ b/website/static/tn/index.html
@@ -26,7 +26,14 @@
 
   // page_view fires automatically and GA4 reads utm_* off this page's URL.
   // sendBeacon keeps it alive through the redirect.
-  gtag('config', 'G-DMRNTVGLRC', { page_title: 'tn-redirect' });
+  // "Redirect — " page_title + a redirect_interstitial event tag this hop so
+  // GA4 filtering can exclude it from content engagement/bounce reports — it
+  // bounces off-site by design and would otherwise read as a 96%-bounce landing.
+  gtag('config', 'G-DMRNTVGLRC', { page_title: 'Redirect — TechNesians Discord' });
+  gtag('event', 'redirect_interstitial', {
+    event_category: 'redirect',
+    redirect_target: 'technesians-discord',
+  });
 
   // Bounce after GA has had its moment. ~500ms is invisible to the user
   // and comfortably enough for the beacon to leave.


### PR DESCRIPTION
## Summary

Makes the by-design redirect pages trivially excludable in GA4, so they stop distorting content engagement / bounce / `(not set)` landing analysis. Follow-up to the acquisition-tagging fix in #398.

## The pages

All three fire a `page_view` then immediately send the user off-site — single-hit, ~100%-bounce sessions by design:

| Path | Destination |
|---|---|
| `/tn` (static) | TechNesians Discord invite |
| `/newsletter/linkedin` | hosted Beehiiv form (LinkedIn vanity path) |
| `/newsletter` (LinkedIn-inbound branch) | hosted Beehiiv form |

## What changed

Each now emits a consistent **`redirect_interstitial`** GA4 event (`event_category: redirect`, `redirect_target: <which>`), and — where the page_view title is reliable (`/tn`, `/newsletter/linkedin`) — carries a **`Redirect — …`** page title. Existing `linkedin_hosted_redirect` funnel events are untouched.

Result: three independent exclusion levers, no custom-dimension registration needed for the title/path ones:
- **By event** — `redirect_interstitial` (register as a custom dimension if you want to filter explorations by it)
- **By page title** — `Page title` does not contain `Redirect —`
- **By path** — exclude `/tn/` and `/newsletter/linkedin/`

## GA4 next steps (dashboard, not code)

To actually clean the reports:
1. **Admin → Data Settings → Data Filters** — confirm bot filtering is active (drops known bots; won't catch Measurement Protocol spam).
2. Add an **exploration segment** "Exclude redirects": exclude events where `event_name = redirect_interstitial`, or where page path is `/tn/` or `/newsletter/linkedin/`.
3. For ghost-referral spam behind the remaining `(not set)`, add a **hostname** condition (`hostname = uncommonengineer.com`) to your explorations.

Build verified passing; `/tn` build output confirmed to contain the event + title tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)